### PR TITLE
add more actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lgtv-ip-control",
   "description": "IP Control module for 2018+ LG TVs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Wes Souza <hey@wes.dev> (https://wes.dev/)",
   "license": "MIT",
   "repository": "WesSouza/lgtv-ip-control",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lgtv-ip-control",
   "description": "IP Control module for 2018+ LG TVs",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "author": "Wes Souza <hey@wes.dev> (https://wes.dev/)",
   "license": "MIT",
   "repository": "WesSouza/lgtv-ip-control",

--- a/src/classes/LGTV.ts
+++ b/src/classes/LGTV.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { EnergySavingLevels, Inputs, Keys } from '../constants/TV';
+import { EnergySavingLevels, Inputs, Keys, Apps } from '../constants/TV';
 import { DefaultSettings } from '../constants/DefaultSettings';
 import { LGEncryption } from './LGEncryption';
 import { TinySocket } from './TinySocket';
@@ -56,6 +56,23 @@ export class LGTV {
 
   async powerOff() {
     return await this.sendCommand(`POWER off`);
+  }
+
+  async launchApp(name: Apps) {
+    return await this.sendCommand(`APP_LAUNCH ${name}`);
+  }
+
+  async setPictureMode(
+    mode:
+      | 'vivid'
+      | 'eco'
+      | 'normal'
+      | 'game'
+      | 'cinema'
+      | 'sports'
+      | 'filmMaker'
+  ) {
+    return await this.sendCommand(`PICTURE_MODE ${mode}`);
   }
 
   powerOn() {

--- a/src/classes/LGTV.ts
+++ b/src/classes/LGTV.ts
@@ -58,7 +58,7 @@ export class LGTV {
     return await this.sendCommand(`POWER off`);
   }
 
-  async launchApp(name: Apps) {
+  async launchApp(name: Apps | string) {
     return await this.sendCommand(`APP_LAUNCH ${name}`);
   }
 

--- a/src/classes/LGTV.ts
+++ b/src/classes/LGTV.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { EnergySavingLevels, Inputs, Keys, Apps } from '../constants/TV';
+import { Apps, EnergySavingLevels, Inputs, Keys, PictureModes } from '../constants/TV';
 import { DefaultSettings } from '../constants/DefaultSettings';
 import { LGEncryption } from './LGEncryption';
 import { TinySocket } from './TinySocket';
@@ -62,16 +62,7 @@ export class LGTV {
     return await this.sendCommand(`APP_LAUNCH ${name}`);
   }
 
-  async setPictureMode(
-    mode:
-      | 'vivid'
-      | 'eco'
-      | 'normal'
-      | 'game'
-      | 'cinema'
-      | 'sports'
-      | 'filmMaker'
-  ) {
+  async setPictureMode(mode: PictureModes) {
     return await this.sendCommand(`PICTURE_MODE ${mode}`);
   }
 

--- a/src/constants/TV.ts
+++ b/src/constants/TV.ts
@@ -1,3 +1,22 @@
+export enum Apps {
+  amazon = 'amazon',
+  googlePlay = 'googleplaymovieswebos',
+  hulu = 'hulu',
+  netflix = 'netflix',
+  slingTV = 'com.movenetworks.app.sling-tv-sling-production',
+  youtube = 'youtube.leanback.v4',
+  vudu = 'vudu',
+  settings = 'com.palm.app.settings',
+  photos = 'com.webos.app.photovideo',
+  music = 'com.webos.app.music',
+  guide = 'com.webos.service.iepg',
+  browser = 'com.webos.app.browser',
+  gallery = 'com.webos.app.igallery',
+  plex = 'cdp-30',
+  disney = 'com.disney.disneyplus-prod',
+  hbomax = 'com.hbo.hbomax',
+}
+
 export enum EnergySavingLevels {
   auto = 'auto',
   screenOff = 'screenoff',
@@ -67,21 +86,12 @@ export enum Keys {
   yellowButton = 'yellowbutton',
 }
 
-export enum Apps {
-  amazon = 'amazon',
-  googlePlay = 'googleplaymovieswebos',
-  hulu = 'hulu',
-  netflix = 'netflix',
-  slingTV = 'com.movenetworks.app.sling-tv-sling-production',
-  youtube = 'youtube.leanback.v4',
-  vudu = 'vudu',
-  settings = 'com.palm.app.settings',
-  photos = 'com.webos.app.photovideo',
-  music = 'com.webos.app.music',
-  guide = 'com.webos.service.iepg',
-  browser = 'com.webos.app.browser',
-  gallery = 'com.webos.app.igallery',
-  plex = 'cdp-30',
-  disney = 'com.disney.disneyplus-prod',
-  hbomax = 'com.hbo.hbomax',
+export enum PictureModes {
+  cinema = 'cinema',
+  eco = 'eco',
+  filmMaker = 'filmMaker',
+  game = 'game',
+  normal = 'normal',
+  sports = 'sports',
+  vivid = 'vivid',
 }

--- a/src/constants/TV.ts
+++ b/src/constants/TV.ts
@@ -66,3 +66,18 @@ export enum Keys {
   volumeUp = 'volumeup',
   yellowButton = 'yellowbutton',
 }
+
+export enum Apps {
+  amazon = 'amazon',
+  googlePlay = 'googleplaymovieswebos',
+  hulu = 'hulu',
+  netflix = 'netflix',
+  slingTV = 'com.movenetworks.app.sling-tv-sling-production',
+  youtube = 'youtube.leanback.v4',
+  vudu = 'vudu',
+  settings = 'com.palm.app.settings',
+  photos = 'com.webos.app.photovideo',
+  music = 'com.webos.app.music',
+  guide = 'com.webos.service.iepg',
+  browser = 'com.webos.app.browser',
+}

--- a/src/constants/TV.ts
+++ b/src/constants/TV.ts
@@ -80,4 +80,8 @@ export enum Apps {
   music = 'com.webos.app.music',
   guide = 'com.webos.service.iepg',
   browser = 'com.webos.app.browser',
+  gallery = 'com.webos.app.igallery',
+  plex = 'cdp-30',
+  disney = 'com.disney.disneyplus-prod',
+  hbomax = 'com.hbo.hbomax',
 }


### PR DESCRIPTION
* Set Picture Mode
* Launch App

Note: Picture Mode only works in SDR.  I've asked LG to fix this so it can be used for HDR and Dolby Vision modes as well, but that will probably only work on 2022 models.  Also, Filmmaker mode only works since 2021 models.