### PR TITLE
Make return types of LGTV methods symmetric with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ model.
 
 **Requirements**
 
-- LG TV (tested on model OLED65B9PUA)
+- LG TV (tested on model OLED65B9PUA and OLED42C2PUA)
 - Node 12+ (at least ES2017)
 
 **Installing**
@@ -90,9 +90,9 @@ const lgtv = new LGTV(
 );
 ```
 
-### `.connect()`
+### `.connect(): Promise<void>`
 
-Connects to the TV using HTTP. Returns a promise.
+Connects to the TV using TCP.
 
 Required before sending any commands.
 
@@ -100,76 +100,75 @@ Required before sending any commands.
 await lgtv.connect();
 ```
 
-### `.disconnect()`
+### `.disconnect(): Promise<void>`
 
-Disconnects from the TV. Returns a promise.
+Disconnects from the TV.
 
 ```ts
 await lgtv.disconnect();
 ```
 
-### `.getCurrentApp()`
+### `.getCurrentApp(): Promise<Apps | string>`
 
-Gets the current app. Returns a promise.
+Gets the current app. May be one of the `Apps` enum or an arbitrary string if
+the app type is unknown.
 
 ```ts
 const currentApp = await lgtv.getCurrentApp();
 ```
 
-### `.getCurrentVolume()`
+### `.getCurrentVolume(): Promise<number>`
 
-Gets the current volume. Returns a promise.
+Gets the current volume as an integer from `0` to `100`.
 
 ```ts
 const currentVolume = await lgtv.getCurrentVolume();
 ```
 
-### `.getIpControlState()`
+### `.getIpControlState(): Promise<boolean>`
 
-Gets the ip control state. Returns a promise.
+Gets the ip control state.
 
 ```ts
 const ipControlState = await lgtv.getIpControlState();
 ```
 
-### `.getMacAddress(type: 'wired' | 'wifi')`
+### `.getMacAddress(type: 'wired' | 'wifi'): Promise<string>`
 
-Gets the mac address by type. Returns a promise.
+Gets the MAC address by network interface.
 
 ```ts
 const macAddress = await lgtv.getMacAddress('wired');
 ```
 
-### `.getMuteState()`
+### `.getMuteState(): Promise<boolean>`
 
-Gets the mute state. Returns a promise.
+Gets the mute state.
 
 ```ts
 const muteState = await lgtv.getMuteState();
 ```
 
-### `.powerOff()`
+### `.powerOff(): Promise<void>`
 
-Powers the TV off. Returns a promise.
+Powers the TV off.
 
 ```ts
 await lgtv.powerOff();
 ```
 
-### `.powerOn()`
+### `.powerOn(): void`
 
 Powers the TV on, using Wake On Lan. Requires MAC address to be set when
 creating the `LGTV` instance.
-
-Returns nothing.
 
 ```ts
 lgtv.powerOn();
 ```
 
-### `.sendKey(key: Keys)`
+### `.sendKey(key: Keys): Promise<void>`
 
-Sends a `key`, as if it was pressed on the TV remote control. Returns a promise.
+Sends a `key`, as if it was pressed on the TV remote control.
 
 ```ts
 await lgtv.sendKey(Keys.menu);
@@ -177,9 +176,10 @@ await lgtv.sendKey(Keys.menu);
 
 See [`Keys`](#Keys) for available keys.
 
-### `.setEnergySaving(level: EnergySavingLevels)`
+### `.setEnergySaving(level: EnergySavingLevels): Promise<void>`
 
-Sets the current energy saving level. Returns a promise.
+Sets the current energy saving level. Note that `screenOff` is known not to
+work for some models.
 
 ```ts
 await lgtv.setEnergySaving(EnergySavingLevels.maximum);
@@ -187,9 +187,9 @@ await lgtv.setEnergySaving(EnergySavingLevels.maximum);
 
 See [`EnergySavingLevels`](#EnergySavingLevels) for available levels.
 
-### `.setInput(input: Inputs)`
+### `.setInput(input: Inputs): Promise<void>`
 
-Sets the current TV input. Returns a promise.
+Sets the current TV input.
 
 ```ts
 await lgtv.setInput(Inputs.hdmi1);
@@ -197,17 +197,17 @@ await lgtv.setInput(Inputs.hdmi1);
 
 See [`Inputs`](#Inputs) for available inputs.
 
-### `.setVolume(volume: number)`
+### `.setVolume(volume: number): Promise<void>`
 
-Sets the volume level, from `0` to `100`. Returns a promise.
+Sets the volume level as an integer from `0` to `100`.
 
 ```ts
 await lgtv.setVolume(15);
 ```
 
-### `.setVolumeMute(isMuted: boolean)`
+### `.setVolumeMute(isMuted: boolean): Promise<void>`
 
-Sets the volume mute state. Returns a promise.
+Sets the volume mute state.
 
 ```ts
 await lgtv.setVolumeMute(false);

--- a/src/classes/LGEncryption.ts
+++ b/src/classes/LGEncryption.ts
@@ -12,6 +12,7 @@ export interface EncryptionSettings {
   keycodeFormat: RegExp;
   messageBlockSize: number;
   messageTerminator: string;
+  responseTerminator: string;
 }
 
 function assertSettings(settings: EncryptionSettings) {
@@ -29,6 +30,7 @@ function assertSettings(settings: EncryptionSettings) {
     keycodeFormat,
     messageBlockSize,
     messageTerminator,
+    responseTerminator,
   } = settings;
   assert(
     typeof encryptionIvLength === 'number' && encryptionIvLength > 0,
@@ -62,6 +64,10 @@ function assertSettings(settings: EncryptionSettings) {
   assert(
     typeof messageTerminator === 'string' && messageTerminator.length > 0,
     'settings.messageTerminator must be a string with length greater than 0',
+  );
+  assert(
+    typeof responseTerminator === 'string' && responseTerminator.length > 0,
+    'settings.responseTerminator must be a string with length greater than 0',
   );
 }
 
@@ -152,8 +158,12 @@ export class LGEncryption {
 
     const cbcDecypher = createDecipheriv('aes-128-cbc', this.derivedKey, iv);
     cbcDecypher.setAutoPadding(false);
-    return cbcDecypher
+    const decrypted = cbcDecypher
       .update(cipher.slice(this.settings.encryptionKeyLength))
       .toString();
+    return decrypted.substring(
+      0,
+      decrypted.indexOf(this.settings.responseTerminator),
+    );
   }
 }

--- a/src/constants/DefaultSettings.ts
+++ b/src/constants/DefaultSettings.ts
@@ -10,6 +10,7 @@ export const DefaultSettings = {
   keycodeFormat: /[A-Z0-9]{8}/,
   messageBlockSize: 16,
   messageTerminator: '\r',
+  responseTerminator: '\n',
   networkPort: 9761,
   networkTimeout: 5000,
   networkWolAddress: '255.255.255.255',

--- a/test/LGEncryption.test.ts
+++ b/test/LGEncryption.test.ts
@@ -50,9 +50,12 @@ describe('decrypt', () => {
       `${encryptedIv}${encryptedData}`,
       'hex',
     );
-    const expectedPlainText = 'VOLUME_MUTE on\x0d\x01';
+    const expectedPlainText = 'VOLUME_MUTE on';
 
-    const encryption = new LGEncryption(exampleKeyCode);
+    const encryption = new LGEncryption(exampleKeyCode, {
+      ...DefaultSettings,
+      responseTerminator: '\r',
+    });
     const decryptedData = encryption.decrypt(exampleCipherText);
 
     expect(decryptedData).toEqual(expectedPlainText);


### PR DESCRIPTION
This is breaking change for anyone currently using the data returned from the `LGTV` methods. However, considering that data is polluted with padding characters from the decryption process, I don't expect many people to be using it. Indeed, I would think anyone currently attempting to parse the raw responses themselves would be happy for the library to do it for them.

In this change, we make `LGEncryption.decrypt()` strip the linefeed character and any padding beyond it. This is symmetric with `LGEncryption.encrypt()` adding the carriage return to messages. Then, LGTV will interpret the responses, retuning booleans, enums, and other parsed strings. For action/setter methods, the return type is void, and an error will be thrown for responses other than 'OK'.

Tests are added for all methods, including validating that errors are throws for all methods. Also, we workaround `net.Server` not gracefully shutting down as documented on macOS, as this was breaking tests on that platform.