### PR TITLE
Implement screen mute functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Sets the volume mute state.
 await lgtv.setVolumeMute(false);
 ```
 
-### `.setScreenMute(mode: ScreenMuteModes)`
+### `.setScreenMute(mode: ScreenMuteModes): Promise<void>`
 
 Sets the current screen mute mode. This can be used to either completely blank
 the screen or just blank the video feed while leaving the OSD visible.
@@ -233,7 +233,7 @@ Returns a promise.
 await lgtv.setScreenMute(ScreenMuteModes.screenmuteon);
 ```
 
-See [`ScreenMuteModes`](#ScreenMuteModes) for available levels.
+See [`ScreenMuteModes`](#ScreenMuteModes) for available modes.
 
 ## Available Lists
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ Sets the volume mute state.
 await lgtv.setVolumeMute(false);
 ```
 
+### `.setScreenMute(mode: ScreenMuteModes)`
+
+Sets the current screen mute mode. This can be used to either completely blank
+the screen or just blank the video feed while leaving the OSD visible.
+Returns a promise.
+
+```ts
+await lgtv.setScreenMute(ScreenMuteModes.screenmuteon);
+```
+
+See [`ScreenMuteModes`](#ScreenMuteModes) for available levels.
+
 ## Available Lists
 
 ### EnergySavingLevels
@@ -299,6 +311,14 @@ await lgtv.setVolumeMute(false);
 | volumeMute      | Mute Toggle          |
 | volumeUp        | Volume Up            |
 | yellowButton    | Yellow Button        |
+
+### ScreenMuteModes
+
+| Key          | Effect                   |
+| ------------ | ------------------------ |
+| screenMuteOn | Blank screen             |
+| videoMuteOn  | Blank video, OSD visible |
+| allMuteOff   | Normal Operation         |
 
 ## Development
 

--- a/src/classes/LGTV.ts
+++ b/src/classes/LGTV.ts
@@ -7,6 +7,7 @@ import {
   Inputs,
   Keys,
   PictureModes,
+  ScreenMuteModes,
 } from '../constants/TV.js';
 import { LGEncryption } from './LGEncryption.js';
 import { TinySocket } from './TinySocket.js';
@@ -102,6 +103,10 @@ export class LGTV {
   async sendKey(key: Keys): Promise<void> {
     assert(Object.values(Keys).includes(key), 'key must be valid');
     throwIfNotOK(await this.sendCommand(`KEY_ACTION ${key}`));
+  }
+
+  async screenMute(mode: ScreenMuteModes) {
+    return await this.sendCommand(`SCREEN_MUTE ${mode}`);
   }
 
   async setEnergySaving(level: EnergySavingLevels): Promise<void> {

--- a/src/classes/LGTV.ts
+++ b/src/classes/LGTV.ts
@@ -105,8 +105,9 @@ export class LGTV {
     throwIfNotOK(await this.sendCommand(`KEY_ACTION ${key}`));
   }
 
-  async screenMute(mode: ScreenMuteModes) {
-    return await this.sendCommand(`SCREEN_MUTE ${mode}`);
+  async setScreenMute(mode: ScreenMuteModes) {
+    assert(Object.values(ScreenMuteModes).includes(mode), 'mode must be valid');
+    throwIfNotOK(await this.sendCommand(`SCREEN_MUTE ${mode}`));
   }
 
   async setEnergySaving(level: EnergySavingLevels): Promise<void> {

--- a/src/constants/TV.ts
+++ b/src/constants/TV.ts
@@ -95,3 +95,9 @@ export enum PictureModes {
   sports = 'sports',
   vivid = 'vivid',
 }
+
+export enum ScreenMuteModes {
+  screenMuteOn = 'screenmuteon',
+  videoMuteOn = 'videomuteon',
+  allMuteOff = 'allmuteoff',
+}

--- a/test/LGTV.test.ts
+++ b/test/LGTV.test.ts
@@ -12,6 +12,7 @@ import {
   Inputs,
   Keys,
   PictureModes,
+  ScreenMuteModes,
 } from '../src/constants/TV.js';
 
 const CRYPT_KEY = 'M9N0AZ62';
@@ -183,6 +184,19 @@ describe.each([
     if (!error) mocking = mockResponse(`KEY_ACTION ${key}`, 'OK');
     await testTV.connect();
     const actual = testTV.sendKey(key as Keys);
+    if (!error) await expect(mocking).resolves.not.toThrow();
+    if (error) await expect(actual).rejects.toThrow();
+    else await expect(actual).resolves.not.toThrow();
+  });
+
+  it.each([
+    { mode: ScreenMuteModes.screenMuteOn, error: false },
+    { mode: 'foobar', error: true },
+  ])('sets picture mode: $mode', async ({ mode, error }) => {
+    let mocking: Promise<void> | null = null;
+    if (!error) mocking = mockResponse(`SCREEN_MUTE ${mode}`, 'OK');
+    await testTV.connect();
+    const actual = testTV.setScreenMute(mode as ScreenMuteModes);
     if (!error) await expect(mocking).resolves.not.toThrow();
     if (error) await expect(actual).rejects.toThrow();
     else await expect(actual).resolves.not.toThrow();


### PR DESCRIPTION
This will allow blanking of screens on newer OLED models where the `screenOff` energy mode doesn't work. Also, the video signal can be blanked without blanking the OSD. This should fix issue #88.