### PR TITLE
Update LGTV.ts

### DIFF
--- a/packages/lgtv-ip-control/src/classes/LGTV.ts
+++ b/packages/lgtv-ip-control/src/classes/LGTV.ts
@@ -139,14 +139,30 @@ export class LGTV {
     throwIfNotOK(await this.sendCommand(`PICTURE_MODE ${mode}`));
   }
 
-  powerOn() {
-    this.socket.wakeOnLan();
+  async powerOn(): Promise<void> {
+    try {
+      throwIfNotOK(await this.sendCommand(`POWER on`));
+    } catch (error) {
+      if (error instanceof ResponseParseError) {
+        this.socket.wakeOnLan();
+      } else {
+        throw error;
+      }
+    }
   }
 
-  powerOnAndConnect(
+  async powerOnAndConnect(
     options?: Parameters<typeof TinySocket.prototype.connect>[0],
-  ) {
-    this.socket.wakeOnLan();
+  ): Promise<void> {
+    try {
+      throwIfNotOK(await this.sendCommand(`POWER on`));
+    } catch (error) {
+      if (error instanceof ResponseParseError) {
+        this.socket.wakeOnLan();
+      } else {
+        throw error;
+      }
+    }
     return this.connect({
       maxRetries: 10,
       ...options,


### PR DESCRIPTION
Please add support for the "POWER on" command. While this command is not documented, I discovered it while trying to wake up my LG C3 TV. The Wake On Lan method does not work consistently for me. However, the TV reliably turns on when I send the "POWER on" command.

Interestingly, Wake On Lan works when I send it from an Android device or a Raspberry Pi, but it fails when I use your library on my PC, where I'm developing a small microservice to control my TV. Additionally, the "POWER on" command is significantly faster than sending magic packets.

Ideally, the best implementation would be to add a new method for this functionality. However, I'm unsure about the most appropriate name for it.