### PR TITLE
fix: add delay to socket error

### DIFF
--- a/packages/lgtv-ip-control/src/classes/TinySocket.ts
+++ b/packages/lgtv-ip-control/src/classes/TinySocket.ts
@@ -157,7 +157,9 @@ export class TinySocket {
 
           this.#client.setTimeout(retryTimeout);
           this.#client.connect(this.settings.networkPort, this.host);
-          this.#client.on('error', connect);
+          this.#client.on('error', (error) => {
+            setTimeout(connect, retryTimeout);
+          });
           this.#client.on('timeout', connect);
           this.#client.on('connect', connected);
           retries++;


### PR DESCRIPTION
The TV network interface often becomes active before the service on port 9761 is fully booted. This results in immediate `ECONNREFUSED` errors.

Previously, the code retried immediately upon failure, consuming all retry attempts instantly before the TV service could start.

Added a `setTimeout` to the error handler to introduce a delay between retries, ensuring the TV has time to finish booting before we stop trying.