### PR TITLE
Support For Logical Channel Number, aka 4-1

### DIFF
--- a/packages/lgtv-ip-control/src/classes/LGTV.ts
+++ b/packages/lgtv-ip-control/src/classes/LGTV.ts
@@ -210,4 +210,10 @@ export class LGTV {
       await this.sendCommand(`VOLUME_MUTE ${isMuted ? 'on' : 'off'}`),
     );
   }
+
+  async setDigitalChannel(channel: string) {
+    throwIfNotOK(
+      await this.sendCommand(`CHANNEL_SETTING_ATSC_DTV ${channel} antennanotphy`)
+    );
+  }
 }

--- a/packages/lgtv-ip-control/src/classes/TinySocket.ts
+++ b/packages/lgtv-ip-control/src/classes/TinySocket.ts
@@ -157,7 +157,9 @@ export class TinySocket {
 
           this.#client.setTimeout(retryTimeout);
           this.#client.connect(this.settings.networkPort, this.host);
-          this.#client.on('error', connect);
+          this.#client.on('error', (error) => {
+            setTimeout(connect, retryTimeout);
+          });
           this.#client.on('timeout', connect);
           this.#client.on('connect', connected);
           retries++;


### PR DESCRIPTION
Here is the United States was use logical channel numbers.  These are not the physical channels that are broadcast is on. These require sending a major and minor number.  I could not figure out how to achieve this with SEND_KEY, so I added support for CHANNEL_SETTING_ATSC_DTV.